### PR TITLE
Enhance handling and writing of git and hosted entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.0
+- Fixed the entries for the git type in the generated recipe files.
+
 ## 0.3.2
 - Change output file suffix to '.inc'
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,16 @@ packages:
 PUB_CACHE_LOCAL ?= "pub_cache"
 PUBSPEC_LOCK_SHA256 = "94efc5507f118c0f473101890dfcfd3d02c93be044b1751ea3f694f96e3673c1"
 
+############################################################
+# Hosted packages
+############################################################
 SRC_URI:append = " https://pub.dev/api/archives/args-2.7.0.tar.gz;name=args;subdir=${PUB_CACHE_LOCAL}/hosted/pub.dev/args-2.7.0;downloadfilename=pub-cache/args-2.7.0.tar.gz"
 SRC_URI[args.sha256sum] = "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04"
-
-SRC_URI:append = " git://github.com/SeungkyunKim/pub2yocto.git;name=pub2yocto;protocol=https;destsuffix=${PUB_CACHE_LOCAL}/git/pub2yocto-6ca590ceeb9977b727a6b014160b33c0df1e9845;nobranch=1" 
-SRCREV_pub2yocto = "6ca590ceeb9977b727a6b014160b33c0df1e9845" 
-SRCREV_FORMAT:append = " pub2yocto" 
+############################################################
+# Git packages
+############################################################
+SRC_URI:append = " git://github.com/SeungkyunKim/pub2yocto.git;name=pub2yocto.git;protocol=https;destsuffix=${PUB_CACHE_LOCAL}/git/cache/pub2yocto.git-e1c8c09065201ef857585bef1766bd2d3d044fa0;nobranch=1;bareclone=1"
+SRCREV_pub2yocto.git = "ed7b8c52aeb848ce5c0f7f53b58009b7d9855ba6"
+SRCREV_FORMAT:append = " pub2yocto"
 ```
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pub2yocto
 description: A Dart package to convert pubspec.lock file to Yocto recipes.
-version: 0.3.2
+version: 0.4.0
 repository: https://github.com/SeungkyunKim/pub2yocto
 
 environment:


### PR DESCRIPTION
:Release Notes:
Improve the processing of Git and hosted entries by adding checks for duplicate URLs in Git entries and enhancing remote resolution.

:Detailed Notes:
For Git entries case, only the source bare repository is populated in `git/cache`. This is automatically regenerated to the version entry when the `pub get` command is executed.

Change-Id: I1dd3584f09b99001fe9e0e589db265a929105ab2