### PR TITLE
Refactor writeEntry function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.1
+- Fixed bug on git src name of SRC_URI
+
 ## 0.4.0
 - Fixed the entries for the git type in the generated recipe files.
 

--- a/lib/pub2yocto.dart
+++ b/lib/pub2yocto.dart
@@ -50,9 +50,9 @@ class PubspecLockParser {
           mode: FileMode.append);
       await outputFile.writeAsString('${entry.checksum()}\n',
           mode: FileMode.append);
-      if (git) {
+      if (entry is GitPubEntry) {
         await outputFile.writeAsString(
-            'SRCREV_FORMAT:append = " ${entry.name}"\n',
+            'SRCREV_FORMAT:append = " ${entry.packageName()}"\n',
             mode: FileMode.append);
       }
     } catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pub2yocto
 description: A Dart package to convert pubspec.lock file to Yocto recipes.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/SeungkyunKim/pub2yocto
 
 environment:


### PR DESCRIPTION
:Release Notes:
Modified `writeEntry` to handle of git entries.

:Detailed Notes:
Removed the boolean 'git' parameter from the `writeEntry` function and instead directly checked if the entry is an instance of `GitPubEntry`. This refactor improves code readability and removes direct boolean parameter reliance, allowing more explicit type checks.