### PR TITLE
Prefer pubspec.lock resolved-ref over local branch tip for SRCREV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+- Prefer `pubspec.lock`'s `resolved-ref` over the local bare clone's branch tip
+when emitting `SRCREV_<pkg>`. Restores lock-file semantics: regenerated `.inc`
+now matches whatever `pub get` resolved, even if upstream branches have moved
+since the lock was written. The for-each-ref result is preserved as a fallback
+for entries without a `resolved-ref` (rare; the multi-package monorepo case).
+
 ## 0.5.0
 - Replace `git ls-remote HEAD` with `git for-each-ref` on local git cache.  Resolve the
 latest commit by examining branch heads in the locally cached bare repository

--- a/lib/pub_entry.dart
+++ b/lib/pub_entry.dart
@@ -295,7 +295,13 @@ class GitPubEntry extends PubEntry {
 
   @override
   String checksum() {
-    return 'SRCREV_${packageName()} = "${_gitRevision ?? description?.ref}"';
+    // Prefer pubspec.lock's resolved-ref (description.ref) over the
+    // for-each-ref result on the local bare clone. Without this, when
+    // upstream pushes new commits between `pub get` runs, the bare
+    // clone's branch tip moves past the locked SHA and SRCREV diverges
+    // from the lock — breaking lock-file semantics. Fall back to
+    // _gitRevision only when the lock has no resolved-ref.
+    return 'SRCREV_${packageName()} = "${description?.ref ?? _gitRevision}"';
   }
 
   // Fetches the commit hash of the remote latest revision for the Git repository.


### PR DESCRIPTION
## Bug

In v0.5.0 (after #15), `GitPubEntry.checksum()` was changed to:

```dart
return 'SRCREV_${packageName()} = "${_gitRevision ?? description?.ref}"';
```

`_gitRevision` is the result of `git for-each-ref --sort=-committerdate --count=1 refs/heads/`
on the local bare clone in `~/.pub-cache/git/cache/`. Whenever upstream
pushes new commits to *any* branch, the next `flutter pub get` fetches
those into the local bare clone, the for-each-ref result moves forward,
and the generated `SRCREV` no longer matches `pubspec.lock`'s
`resolved-ref`.

### Reproduction

1. Add a git package with explicit `ref:` to `pubspec.yaml`, run `pub get` → lock pinned to SHA `A`.
2. Maintainer pushes commit `B` to a branch upstream.
3. Run `pub get` again → lock still pinned to `A`, but bare clone now has `B` as branch tip.
4. Run `dart run pub2yocto` → generated `SRCREV` is `B`, not `A`.

This breaks Yocto builds: `do_unpack` extracts `B`, but the app code in `${WORKDIR}/app` was built (in host) against `A`, causing version skew and `do_configure` failures.

## Fix

Invert the priority so `description.ref` (which returns `resolved-ref`
from pubspec.lock) wins when present:

```dart
return 'SRCREV_${packageName()} = "${description?.ref ?? _gitRevision}"';
```

The `_gitRevision` fallback is preserved for the rare case where
`resolved-ref` is missing from the lock — the original monorepo
motivation cited in the comment block above `resolveRemote()`.

## Testing

Verified locally on two webOS Flutter apps (~30 git deps each, including
both single-package repos with explicit `ref:` and monorepo repos). All
generated `SRCREV_*` lines now match `pubspec.lock`'s `resolved-ref`,
including:

- explicit SHA refs (`ref: 46cc9d93...`)
- branch refs (`ref: master` → resolved to current SHA at lock time)
- tag refs (`ref: 0.15.0` → resolved to underlying commit SHA)

No regressions observed in monorepo packages where multiple sub-packages
share a URL.